### PR TITLE
Bootstrap Gradle configuration for Compose project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+local.properties
+.DS_Store
+/build/
+app/build/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,91 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.oja.app"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.oja.app"
+        minSdk = 23
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+
+        vectorDrawables { useSupportLibrary = true }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug { isMinifyEnabled = false }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions { jvmTarget = "17" }
+
+    buildFeatures { compose = true }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+
+    packaging {
+        resources.excludes += setOf(
+            "/META-INF/{AL2.0,LGPL2.1}",
+            "META-INF/INDEX.LIST"
+        )
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2025.08.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.8.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+
+    // Maps Compose (explicit version as per docs)
+    implementation("com.google.maps.android:maps-compose:6.7.1") // :contentReference[oaicite:3]{index=3}
+    implementation("com.google.android.gms:play-services-maps:19.0.0")
+    implementation("com.google.android.gms:play-services-location:21.0.1") // :contentReference[oaicite:4]{index=4}
+
+    // WebSockets + JSON (Ktor 3.x)
+    implementation("io.ktor:ktor-client-okhttp:3.2.3") // :contentReference[oaicite:5]{index=5}
+    implementation("io.ktor:ktor-client-websockets:3.2.3")
+    implementation("io.ktor:ktor-client-content-negotiation:3.2.3")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.2.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+
+    // Image loading
+    implementation("io.coil-kt:coil-compose:2.7.0")
+
+    // QR (scan/generate)
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0") // :contentReference[oaicite:6]{index=6}
+    implementation("com.google.zxing:core:3.5.3")
+
+    // Payments (adapters + SDKs)
+    implementation("com.paystack.android:paystack-ui:0.0.10") // check docs for latest before ship :contentReference[oaicite:7]{index=7}
+    implementation("com.github.flutterwave.rave-android:rave_android:2.2.1") // via JitPack :contentReference[oaicite:8]{index=8}
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules for the OJA app. Add custom keep rules as backend integrations mature.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.4.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+APP_HOME="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER_JAR="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
+
+if [ -f "$WRAPPER_JAR" ]; then
+  exec "${JAVA_HOME:-$(command -v java)}" -jar "$WRAPPER_JAR" "$@"
+fi
+
+if command -v gradle >/dev/null 2>&1; then
+  exec gradle "$@"
+fi
+
+echo "Gradle wrapper JAR not found and 'gradle' command unavailable. Install Gradle or generate the wrapper jar." >&2
+exit 1

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,15 @@
+@ECHO OFF
+SETLOCAL
+SET APP_HOME=%~dp0
+SET WRAPPER_JAR=%APP_HOME%gradle\wrapper\gradle-wrapper.jar
+IF EXIST "%WRAPPER_JAR%" (
+  "%JAVA_HOME%\bin\java.exe" -jar "%WRAPPER_JAR%" %*
+  EXIT /B %ERRORLEVEL%
+)
+WHERE gradle >NUL 2>&1
+IF %ERRORLEVEL% EQU 0 (
+  gradle %*
+  EXIT /B %ERRORLEVEL%
+)
+ECHO Gradle wrapper JAR not found and 'gradle' command unavailable. Install Gradle or generate the wrapper jar.
+EXIT /B 1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+rootProject.name = "OJA"
+include(":app")


### PR DESCRIPTION
## Summary
- configure project-level Gradle files with the required repositories and plugins for the OJA Compose app
- add the app module build script with Compose, Maps, Ktor, ZXing, and payment SDK dependencies plus supporting Gradle properties
- provide Gradle wrapper scripts, distribution settings, and ignore rules to prepare the Android project shell

## Testing
- ⚠️ `./gradlew help --console=plain` *(terminated after extended dependency resolution; Android toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf008662d08325b86e9b2311740113