### PR TITLE
Replace binary Gradle wrapper jar with scripted downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/build/
+/app/build/
+/.gradle/
+/local.properties
+/.idea/
+.DS_Store
+*.iml
+gradle/wrapper/gradle-wrapper.jar
+gradle/wrapper/gradle-wrapper-shared.jar
+.gradle-dist/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,91 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.oja.app"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.oja.app"
+        minSdk = 23
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+
+        vectorDrawables { useSupportLibrary = true }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug { isMinifyEnabled = false }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions { jvmTarget = "17" }
+
+    buildFeatures { compose = true }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+
+    packaging {
+        resources.excludes += setOf(
+            "/META-INF/{AL2.0,LGPL2.1}",
+            "META-INF/INDEX.LIST"
+        )
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2025.08.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.8.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+
+    // Maps Compose (explicit version as per docs)
+    implementation("com.google.maps.android:maps-compose:6.7.1")
+    implementation("com.google.android.gms:play-services-maps:19.0.0")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
+
+    // WebSockets + JSON (Ktor 3.x)
+    implementation("io.ktor:ktor-client-okhttp:3.2.3")
+    implementation("io.ktor:ktor-client-websockets:3.2.3")
+    implementation("io.ktor:ktor-client-content-negotiation:3.2.3")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.2.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+
+    // Image loading
+    implementation("io.coil-kt:coil-compose:2.7.0")
+
+    // QR (scan/generate)
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
+    implementation("com.google.zxing:core:3.5.3")
+
+    // Payments (adapters + SDKs)
+    implementation("com.paystack.android:paystack-ui:0.0.10")
+    implementation("com.github.flutterwave.rave-android:rave_android:2.2.1")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Keep empty until needed

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:name=".OjaApp"
+        android:allowBackup="true"
+        android:label="OJA"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_key"/>
+    </application>
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+</manifest>

--- a/app/src/main/java/com/oja/app/MainActivity.kt
+++ b/app/src/main/java/com/oja/app/MainActivity.kt
@@ -1,0 +1,15 @@
+package com.oja.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.ExperimentalMaterial3Api
+import com.oja.app.ui.AppRoot
+
+class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { AppRoot() }
+    }
+}

--- a/app/src/main/java/com/oja/app/OjaApp.kt
+++ b/app/src/main/java/com/oja/app/OjaApp.kt
@@ -1,0 +1,5 @@
+package com.oja.app
+
+import android.app.Application
+
+class OjaApp : Application()

--- a/app/src/main/java/com/oja/app/data/Models.kt
+++ b/app/src/main/java/com/oja/app/data/Models.kt
@@ -1,0 +1,30 @@
+package com.oja.app.data
+
+enum class DeliveryMethod { BICYCLE, BIKE, CAR }
+
+data class Store(val id: String, val name: String)
+data class Product(val id: String, val storeId: String, val name: String, val price: Long)
+
+data class CartItem(val product: Product, val qty: Int)
+data class CartState(
+    val items: List<CartItem> = emptyList(),
+    val acceptedExtraFees: Set<String> = emptySet()
+) {
+    val groupedByStore: Map<String, List<CartItem>> get() = items.groupBy { it.product.storeId }
+    val subtotal: Long get() = items.sumOf { it.product.price * it.qty }
+}
+
+data class Order(val id: String, val storeIds: List<String>, val method: DeliveryMethod, val total: Long)
+
+data class JobTicket(
+    val id: String,
+    val orderId: String,
+    val method: DeliveryMethod,
+    val pickupLat: Double,
+    val pickupLng: Double,
+    val dropLat: Double,
+    val dropLng: Double,
+    val claimedByTransporterId: String? = null
+)
+
+data class TransporterProfile(val id: String, val name: String, val methods: Set<DeliveryMethod>)

--- a/app/src/main/java/com/oja/app/data/Repo.kt
+++ b/app/src/main/java/com/oja/app/data/Repo.kt
@@ -1,0 +1,52 @@
+package com.oja.app.data
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlin.random.Random
+
+object Repo {
+    private val _cart = MutableStateFlow(CartState())
+    val cart: StateFlow<CartState> = _cart
+
+    private val _jobs = MutableStateFlow<List<JobTicket>>(emptyList())
+    val jobs: StateFlow<List<JobTicket>> = _jobs
+
+    private val stores = listOf(
+        Store("s1","Idumota Plastics"),
+        Store("s2","Lekki Grocer"),
+        Store("s3","Ajah Tools")
+    )
+    val products = listOf(
+        Product("p1","s1","Broom", 1200),
+        Product("p2","s2","Indomie Pack", 5000),
+        Product("p3","s3","Spanner", 2500)
+    )
+
+    fun addToCart(p: Product) { _cart.update { it.copy(items = it.items + CartItem(p, 1)) } }
+    fun acceptExtraFeeFor(storeId: String) { _cart.update { it.copy(acceptedExtraFees = it.acceptedExtraFees + storeId) } }
+    fun clearCart() { _cart.value = CartState() }
+
+    fun createOrder(method: DeliveryMethod): Order {
+        val cs = _cart.value
+        val storeIds = cs.groupedByStore.keys.toList()
+        val base = cs.subtotal
+        val extraFee = (storeIds.size - 1).coerceAtLeast(0) * 700
+        val total = base + extraFee
+        val order = Order(id = "o-${Random.nextInt(10000, 99999)}", storeIds, method, total)
+        val jt = JobTicket(
+            id = "j-${Random.nextInt(10000,99999)}",
+            orderId = order.id,
+            method = method,
+            pickupLat = 6.449, pickupLng = 3.602,
+            dropLat = 6.453, dropLng = 3.611
+        )
+        _jobs.update { listOf(jt) + it }
+        _cart.value = CartState()
+        return order
+    }
+
+    fun claimJob(jobId: String, transporterId: String) {
+        _jobs.update { list -> list.map { if (it.id == jobId) it.copy(claimedByTransporterId = transporterId) else it } }
+    }
+}

--- a/app/src/main/java/com/oja/app/navigation/Nav.kt
+++ b/app/src/main/java/com/oja/app/navigation/Nav.kt
@@ -1,0 +1,14 @@
+package com.oja.app.navigation
+
+sealed class Route(val path: String) {
+    data object Welcome: Route("welcome")
+    data object Home: Route("home")
+    data object Cart: Route("cart")
+    data object Jobs: Route("jobs")
+    data object Track: Route("track/{orderId}") {
+        fun path(orderId: String) = "track/$orderId"
+    }
+    data object TransporterSignup: Route("transporter")
+    data object VendorSignup: Route("vendor")
+    data object Payments: Route("payments")
+}

--- a/app/src/main/java/com/oja/app/net/WsConfig.kt
+++ b/app/src/main/java/com/oja/app/net/WsConfig.kt
@@ -1,0 +1,6 @@
+package com.oja.app.net
+
+object WsConfig {
+    // Replace with your backend when ready. Leave as-is; UI will simulate.
+    const val WS_URL = "wss://example.com/oja/ws"
+}

--- a/app/src/main/java/com/oja/app/ui/AppRoot.kt
+++ b/app/src/main/java/com/oja/app/ui/AppRoot.kt
@@ -1,0 +1,30 @@
+package com.oja.app.ui
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.oja.app.navigation.Route
+import com.oja.app.ui.screens.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppRoot() {
+    OjaTheme {
+        val nav = rememberNavController()
+        NavHost(navController = nav, startDestination = Route.Welcome.path) {
+            composable(Route.Welcome.path) { WelcomeScreen(onStart = { nav.navigate(Route.Home.path) }) }
+            composable(Route.Home.path) { HomeScreen(nav) }
+            composable(Route.Cart.path) { CartScreen(nav) }
+            composable(Route.Jobs.path) { JobsDashboardScreen(nav) }
+            composable(Route.TransporterSignup.path) { TransporterSignupScreen(nav) }
+            composable(Route.VendorSignup.path) { VendorSignupScreen(nav) }
+            composable(Route.Payments.path) { PaymentsScreen(nav) }
+            composable(Route.Track.path) { backStack ->
+                val orderId = backStack.arguments?.getString("orderId").orEmpty()
+                TrackScreen(orderId = orderId, onBack = { nav.popBackStack() })
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/Theme.kt
+++ b/app/src/main/java/com/oja/app/ui/Theme.kt
@@ -1,0 +1,12 @@
+package com.oja.app.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val scheme = darkColorScheme()
+
+@Composable
+fun OjaTheme(content: @Composable () -> Unit) {
+    MaterialTheme(colorScheme = scheme, content = content)
+}

--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -1,0 +1,78 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.DeliveryMethod
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+
+@Composable
+fun CartScreen(nav: NavHostController) {
+    val cart by Repo.cart.collectAsState()
+    var method by remember { mutableStateOf(DeliveryMethod.BIKE) }
+    var pendingStoreId by remember { mutableStateOf<String?>(null) }
+
+    val groups = cart.groupedByStore
+    val extraStores = (groups.keys.size - 1).coerceAtLeast(0)
+    val extraFee = extraStores * 700L
+    val needsAccept = groups.keys.any { it !in cart.acceptedExtraFees } && groups.keys.size > 1
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        LazyColumn(Modifier.weight(1f)) {
+            groups.forEach { (storeId, items) ->
+                item { Text("Store: $storeId") }
+                items(items.size) { i ->
+                    val it = items[i]
+                    Text("${it.product.name} x${it.qty} — ₦${it.product.price}")
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button({ method = DeliveryMethod.BICYCLE }) { Text("Bicycle") }
+            Button({ method = DeliveryMethod.BIKE }) { Text("Bike") }
+            Button({ method = DeliveryMethod.CAR }) { Text("Car") }
+        }
+        Spacer(Modifier.height(8.dp))
+        Text("Subtotal: ₦${cart.subtotal}")
+        if (extraStores > 0) Text("Extra store fee: ₦$extraFee")
+        Spacer(Modifier.height(8.dp))
+        Button({
+            if (needsAccept) {
+                pendingStoreId = groups.keys.first { it !in cart.acceptedExtraFees }
+            } else {
+                val order = Repo.createOrder(method)
+                nav.navigate(Route.Track.path(order.id))
+            }
+        }, enabled = cart.items.isNotEmpty()) { Text("Checkout") }
+    }
+
+    val sid = pendingStoreId
+    if (sid != null) {
+        AlertDialog(
+            onDismissRequest = { pendingStoreId = null },
+            title = { Text("Extra logistics cost") },
+            text = { Text("Adding items from $sid adds courier cost. Accept?") },
+            confirmButton = {
+                TextButton({
+                    Repo.acceptExtraFeeFor(sid)
+                    pendingStoreId = null
+                }) { Text("Accept") }
+            },
+            dismissButton = { TextButton({ pendingStoreId = null }) { Text("Cancel") } }
+        )
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
@@ -1,0 +1,38 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+
+@Composable
+fun HomeScreen(nav: NavHostController) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button({ nav.navigate(Route.Cart.path) }) { Text("Cart") }
+            Button({ nav.navigate(Route.Jobs.path) }) { Text("Jobs") }
+            Button({ nav.navigate(Route.TransporterSignup.path) }) { Text("Be a Transporter") }
+        }
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(Repo.products.size) { idx ->
+                val p = Repo.products[idx]
+                Card(Modifier.fillMaxWidth().padding(2.dp)) {
+                    Column(Modifier.padding(12.dp)) {
+                        Text(p.name)
+                        Text("₦${p.price}")
+                        Spacer(Modifier.height(8.dp))
+                        Button({ Repo.addToCart(p) }) { Text("Add to Cart") }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
@@ -1,0 +1,59 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.JobTicket
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun JobsDashboardScreen(nav: NavHostController) {
+    val jobs by Repo.jobs.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Unclaimed Deliveries")
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(jobs.size) { i ->
+                val j = jobs[i]
+                JobCard(j, onTrack = { nav.navigate(Route.Track.path(j.orderId)) }, onClaim = {
+                    scope.launch {
+                        delay(300)
+                        Repo.claimJob(j.id, transporterId = "tx-001")
+                    }
+                })
+            }
+        }
+    }
+}
+
+@Composable
+private fun JobCard(j: JobTicket, onTrack: () -> Unit, onClaim: () -> Unit) {
+    Card(Modifier.fillMaxWidth().clickable(onClick = onTrack)) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Job ${j.id} • ${j.method}")
+            Text("Order ${j.orderId}")
+            val status = if (j.claimedByTransporterId == null) "Unclaimed" else "Claimed by ${j.claimedByTransporterId}"
+            Text(status)
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onTrack) { Text("Track") }
+                if (j.claimedByTransporterId == null) Button(onClaim) { Text("Claim") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/PaymentsScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/PaymentsScreen.kt
@@ -1,0 +1,20 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun PaymentsScreen(nav: NavHostController) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Payments (Test Mode)")
+        Spacer(Modifier.height(8.dp))
+        Button({ /* trigger Paystack PaymentSheet with server access_code */ }) { Text("Pay with Paystack") }
+        Spacer(Modifier.height(8.dp))
+        Button({ /* open Flutterwave Drop-In */ }) { Text("Pay with Flutterwave") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
@@ -1,0 +1,70 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.Polyline
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberMarkerState
+import com.oja.app.data.Repo
+import kotlinx.coroutines.delay
+import kotlin.math.min
+
+@Composable
+fun TrackScreen(orderId: String, onBack: () -> Unit) {
+    val job = Repo.jobs.value.firstOrNull { it.orderId == orderId }
+    Column(Modifier.fillMaxSize()) {
+        if (job == null) {
+            Text("No tracking for $orderId")
+            Button(onBack) { Text("Back") }
+            return
+        }
+
+        val start = com.google.android.gms.maps.model.LatLng(job.pickupLat, job.pickupLng)
+        val end = com.google.android.gms.maps.model.LatLng(job.dropLat, job.dropLng)
+        val cameraPositionState = rememberCameraPositionState {
+            position = com.google.android.gms.maps.model.CameraPosition.fromLatLngZoom(start, 13f)
+        }
+
+        var progress by remember { mutableStateOf(0f) }
+        LaunchedEffect(orderId) {
+            while (progress < 1f) {
+                delay(800)
+                progress = min(1f, progress + 0.08f)
+            }
+        }
+
+        val current = com.google.android.gms.maps.model.LatLng(
+            start.latitude + (end.latitude - start.latitude) * progress,
+            start.longitude + (end.longitude - start.longitude) * progress
+        )
+
+        if (com.google.android.libraries.maps.BuildConfig.VERSION_NAME != null) {
+            GoogleMap(
+                modifier = Modifier.weight(1f),
+                cameraPositionState = cameraPositionState
+            ) {
+                Polyline(points = listOf(start, end))
+                Marker(state = rememberMarkerState(position = start), title = "Pickup")
+                Marker(state = rememberMarkerState(position = end), title = "Dropoff")
+                Marker(state = rememberMarkerState(position = current), title = "Courier")
+            }
+        } else {
+            Box(Modifier.weight(1f)) { Text("Map placeholder (add Maps API key)") }
+        }
+        Row(Modifier.fillMaxWidth().padding(12.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onBack) { Text("Back") }
+            Text("Progress: ${(progress * 100).toInt()}%")
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
@@ -1,0 +1,32 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.DeliveryMethod
+
+@Composable
+fun TransporterSignupScreen(nav: NavHostController) {
+    var name by remember { mutableStateOf("") }
+    var bike by remember { mutableStateOf(true) }
+    var bicycle by remember { mutableStateOf(false) }
+    var car by remember { mutableStateOf(false) }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Transporter Registration")
+        Row { Checkbox(bicycle, { bicycle = it }); Text("Bicycle") }
+        Row { Checkbox(bike, { bike = it }); Text("Bike") }
+        Row { Checkbox(car, { car = it }); Text("Car") }
+        Spacer(Modifier.height(8.dp))
+        Button({ nav.popBackStack() }) { Text("Submit") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/VendorSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/VendorSignupScreen.kt
@@ -1,0 +1,18 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun VendorSignupScreen(nav: NavHostController) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Vendor Onboarding")
+        Spacer(Modifier.height(8.dp))
+        Button({ nav.popBackStack() }) { Text("Submit") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
@@ -1,0 +1,28 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.oja.app.R
+
+@Composable
+fun WelcomeScreen(onStart: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(16.dp))
+        Text("Welcome to OJA", textAlign = TextAlign.Center)
+        // Placeholder hero; swap with generated “field agents” artwork later.
+        Image(painterResource(id = R.drawable.ic_launcher_foreground), contentDescription = "Agents")
+        Button(onClick = onStart, modifier = Modifier.fillMaxWidth()) { Text("Enter Market") }
+    }
+}

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF6200EE"
+        android:pathData="M54,12a42,42 0,1 1,-0.01 0"/>
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M54,30a24,24 0,1 1,-0.01 0"/>
+    <path
+        android:fillColor="#FF6200EE"
+        android:pathData="M54,42a12,12 0,1 1,-0.01 0"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">OJA</string>
+    <string name="google_maps_key">YOUR_MAPS_API_KEY_HERE</string>
+    <string name="welcome_title">Welcome to OJA</string>
+    <string name="welcome_sub">Your neighborhood market—street to doorstep</string>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.4.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+# Simplified Gradle wrapper script that keeps the repository free of binary wrapper jars.
+# The script reads gradle/wrapper/gradle-wrapper.properties, downloads the declared
+# distribution on demand, caches it inside .gradle-dist/, and then executes the
+# distribution's gradle binary with the provided arguments.
+
+set -e
+
+APP_HOME=$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)
+WRAPPER_PROPS="$APP_HOME/gradle/wrapper/gradle-wrapper.properties"
+
+if [ ! -f "$WRAPPER_PROPS" ]; then
+    echo "ERROR: gradle-wrapper.properties not found." >&2
+    exit 1
+fi
+
+distributionUrl=$(grep '^distributionUrl=' "$WRAPPER_PROPS" | tail -n 1 | cut -d'=' -f2-)
+distributionUrl=$(printf '%s' "$distributionUrl" | sed 's#\\##g')
+if [ -z "$distributionUrl" ]; then
+    echo "ERROR: distributionUrl not defined in gradle-wrapper.properties." >&2
+    exit 1
+fi
+
+version=$(printf '%s' "$distributionUrl" | sed -n 's/.*gradle-\([0-9][0-9A-Za-z\.-]*\)-.*/\1/p')
+if [ -z "$version" ]; then
+    echo "ERROR: Unable to determine Gradle version from $distributionUrl" >&2
+    exit 1
+fi
+
+DIST_DIR="$APP_HOME/.gradle-dist"
+INSTALL_DIR="$DIST_DIR/gradle-$version"
+GRADLE_BIN="$INSTALL_DIR/bin/gradle"
+
+if [ ! -x "$GRADLE_BIN" ]; then
+    tmpDist=$(mktemp "${TMPDIR:-/tmp}/gradle-dist-XXXXXX.zip") || {
+        echo "ERROR: Unable to create temporary file for Gradle download." >&2
+        exit 1
+    }
+    echo "Downloading Gradle $version from $distributionUrl" >&2
+    if command -v curl >/dev/null 2>&1; then
+        if ! curl -fL "$distributionUrl" -o "$tmpDist"; then
+            rm -f "$tmpDist"
+            echo "ERROR: Failed to download Gradle using curl." >&2
+            exit 1
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if ! wget -O "$tmpDist" "$distributionUrl"; then
+            rm -f "$tmpDist"
+            echo "ERROR: Failed to download Gradle using wget." >&2
+            exit 1
+        fi
+    else
+        rm -f "$tmpDist"
+        echo "ERROR: curl or wget is required to download the Gradle distribution." >&2
+        exit 1
+    fi
+
+    if ! command -v unzip >/dev/null 2>&1; then
+        rm -f "$tmpDist"
+        echo "ERROR: unzip is required to extract the Gradle distribution." >&2
+        exit 1
+    fi
+
+    mkdir -p "$DIST_DIR"
+    rm -rf "$INSTALL_DIR"
+    if ! unzip -q "$tmpDist" -d "$DIST_DIR"; then
+        rm -f "$tmpDist"
+        echo "ERROR: Failed to extract Gradle distribution." >&2
+        exit 1
+    fi
+    rm -f "$tmpDist"
+fi
+
+exec "$GRADLE_BIN" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,44 @@
+@echo off
+setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%"=="" set DIRNAME=.
+for %%i in ("%DIRNAME%") do set APP_HOME=%%~fi
+
+set WRAPPER_PROPS=%APP_HOME%\gradle\wrapper\gradle-wrapper.properties
+if not exist "%WRAPPER_PROPS%" (
+    echo ERROR: gradle-wrapper.properties not found. 1>&2
+    goto fail
+)
+
+for /f "tokens=1,* delims==" %%A in ('findstr /R "^distributionUrl=" "%WRAPPER_PROPS%"') do set DIST_URL=%%B
+if "%DIST_URL%"=="" (
+    echo ERROR: distributionUrl not defined in gradle-wrapper.properties. 1>&2
+    goto fail
+)
+
+set DIST_URL=%DIST_URL:\=%
+for /f %%V in ('powershell -NoProfile -ExecutionPolicy Bypass -Command "param($$url) if ($$url -match 'gradle-([0-9A-Za-z\.-]+)-') { Write-Output $$matches[1] }" "%DIST_URL%"') do set GRADLE_VERSION=%%V
+if "%GRADLE_VERSION%"=="" (
+    echo ERROR: Unable to determine Gradle version from %DIST_URL%. 1>&2
+    goto fail
+)
+
+set DIST_DIR=%APP_HOME%\.gradle-dist
+set INSTALL_DIR=%DIST_DIR%\gradle-%GRADLE_VERSION%
+set GRADLE_CMD=%INSTALL_DIR%\bin\gradle.bat
+
+if not exist "%GRADLE_CMD%" (
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "param($$url,$$installDir) $ProgressPreference='SilentlyContinue'; $distDir = Split-Path -Parent $$installDir; if (!(Test-Path $distDir)) { New-Item -ItemType Directory -Path $distDir -Force | Out-Null; } if (Test-Path $$installDir) { Remove-Item $$installDir -Recurse -Force; } $zipPath = [System.IO.Path]::GetTempFileName(); Invoke-WebRequest -Uri $$url -OutFile $zipPath -UseBasicParsing; Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $distDir); Remove-Item $zipPath" "%DIST_URL%" "%INSTALL_DIR%"
+    if not exist "%GRADLE_CMD%" goto fail
+)
+
+call "%GRADLE_CMD%" %*
+endlocal
+exit /b %ERRORLEVEL%
+
+:fail
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+endlocal
+exit /b %EXIT_CODE%

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+rootProject.name = "OJA"
+include(":app")


### PR DESCRIPTION
## Summary
- remove the committed gradle-wrapper.jar to comply with the no-binaries policy and ignore future jar generations
- rewrite the Unix `gradlew` script to fetch the configured Gradle distribution on demand and execute its launcher
- update the Windows `gradlew.bat` script with matching download/extract logic using PowerShell

## Testing
- ./gradlew --version

------
https://chatgpt.com/codex/tasks/task_e_68cf008662d08325b86e9b2311740113