### PR TITLE
Add shared models repository and websocket config

### DIFF
--- a/data/Models.kt
+++ b/data/Models.kt
@@ -1,0 +1,216 @@
+package data
+
+import java.time.Instant
+
+/**
+ * Supported delivery options across the marketplace along with the metadata
+ * the UI needs for ETA messaging and baseline fee calculations.
+ */
+enum class DeliveryMethod(
+    val label: String,
+    val etaMinutes: IntRange,
+    val baseFee: Int
+) {
+    BICYCLE(
+        label = "Bicycle Courier",
+        etaMinutes = 35..55,
+        baseFee = 600
+    ),
+    MOTORBIKE(
+        label = "Bike Courier",
+        etaMinutes = 25..45,
+        baseFee = 900
+    ),
+    CAR(
+        label = "Car Courier",
+        etaMinutes = 40..65,
+        baseFee = 1300
+    );
+
+    val etaLabel: String get() = "${etaMinutes.first}-${etaMinutes.last} mins"
+}
+
+/**
+ * Track the lifecycle of an order as it advances from the cart to delivery.
+ */
+enum class OrderStatus {
+    DRAFT,
+    SUBMITTED,
+    PREPARING,
+    READY_FOR_PICKUP,
+    IN_TRANSIT,
+    DELIVERED,
+    CANCELLED
+}
+
+/**
+ * Job tickets surface to transporters and operations. They progress from
+ * unclaimed to delivered as riders take ownership and complete the run.
+ */
+enum class JobState {
+    UNCLAIMED,
+    CLAIMED,
+    EN_ROUTE,
+    DELIVERED
+}
+
+/**
+ * Basic representation of a geographic address used for both pickups and drop-offs.
+ */
+data class Address(
+    val label: String,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val additionalDirections: String? = null
+)
+
+/**
+ * Stores are the origin point for catalogue items and pickups.
+ */
+data class Store(
+    val id: String,
+    val name: String,
+    val category: String,
+    val pickupAddress: Address
+)
+
+/**
+ * A product sold by a store. Price is in Kobo to avoid floating point rounding issues.
+ */
+data class Product(
+    val id: String,
+    val storeId: String,
+    val name: String,
+    val unitPriceKobo: Long,
+    val imageUrl: String? = null,
+    val unitLabel: String = "unit"
+)
+
+/**
+ * Single line item in a cart representing a quantity of a product.
+ */
+data class CartLine(
+    val product: Product,
+    val quantity: Int
+) {
+    init {
+        require(quantity > 0) { "Quantity must be greater than zero" }
+    }
+
+    val lineTotalKobo: Long get() = product.unitPriceKobo * quantity
+}
+
+/**
+ * Buyer cart with helper logic for surcharge acceptance and totals.
+ */
+data class Cart(
+    val items: List<CartLine> = emptyList(),
+    val deliveryMethod: DeliveryMethod = DeliveryMethod.MOTORBIKE,
+    val dropOffAddress: Address? = null,
+    val acceptedExtraStoreIds: Set<String> = emptySet()
+) {
+    val subtotalKobo: Long get() = items.sumOf(CartLine::lineTotalKobo)
+
+    val storeSequence: List<String> get() = items.map { it.product.storeId }.distinct()
+
+    val primaryStoreId: String? get() = storeSequence.firstOrNull()
+
+    val extraStoreIds: Set<String> get() = storeSequence.drop(1).toSet()
+
+    val pendingAcceptanceStoreIds: Set<String>
+        get() = extraStoreIds - acceptedExtraStoreIds
+
+    val hasPendingSurchargeAcceptance: Boolean get() = pendingAcceptanceStoreIds.isNotEmpty()
+
+    fun markSurchargeAccepted(storeId: String): Cart =
+        copy(acceptedExtraStoreIds = acceptedExtraStoreIds + storeId)
+
+    fun toggleSurchargeAcceptance(storeId: String): Cart =
+        if (storeId in acceptedExtraStoreIds) {
+            copy(acceptedExtraStoreIds = acceptedExtraStoreIds - storeId)
+        } else {
+            markSurchargeAccepted(storeId)
+        }
+
+    fun removeStoreAcceptance(storeId: String): Cart =
+        copy(acceptedExtraStoreIds = acceptedExtraStoreIds - storeId)
+
+    fun surchargeKobo(extraStoreFeeKobo: Long): Long = extraStoreIds.size * extraStoreFeeKobo
+
+    fun deliveryFeeKobo(): Long = deliveryMethod.baseFee * 100L
+
+    fun totalKobo(extraStoreFeeKobo: Long): Long =
+        subtotalKobo + deliveryFeeKobo() + surchargeKobo(extraStoreFeeKobo)
+
+    fun upsertLine(product: Product, quantity: Int): Cart {
+        require(quantity > 0) { "Quantity must be greater than zero" }
+        val updatedItems = items.toMutableList()
+        val index = updatedItems.indexOfFirst { it.product.id == product.id }
+        if (index >= 0) {
+            updatedItems[index] = CartLine(product, quantity)
+        } else {
+            updatedItems += CartLine(product, quantity)
+        }
+        val newCart = copy(items = updatedItems)
+        val stillInCartStoreIds = newCart.items.map { it.product.storeId }.toSet()
+        val filteredAcceptance = newCart.acceptedExtraStoreIds.filterTo(mutableSetOf()) { it in stillInCartStoreIds }
+        return newCart.copy(acceptedExtraStoreIds = filteredAcceptance)
+    }
+
+    fun removeLine(productId: String): Cart {
+        val filteredItems = items.filterNot { it.product.id == productId }
+        val newCart = copy(items = filteredItems)
+        val remainingStoreIds = newCart.items.map { it.product.storeId }.toSet()
+        val filteredAcceptance = newCart.acceptedExtraStoreIds.filterTo(mutableSetOf()) { it in remainingStoreIds }
+        return newCart.copy(acceptedExtraStoreIds = filteredAcceptance)
+    }
+}
+
+/**
+ * Order snapshot captured at checkout.
+ */
+data class Order(
+    val id: String,
+    val status: OrderStatus,
+    val items: List<CartLine>,
+    val storeSequence: List<String>,
+    val deliveryMethod: DeliveryMethod,
+    val dropOffAddress: Address,
+    val subtotalKobo: Long,
+    val deliveryFeeKobo: Long,
+    val surchargeKobo: Long,
+    val totalKobo: Long,
+    val createdAt: Instant,
+    val extraStoreIds: Set<String>
+) {
+    val storeCount: Int get() = storeSequence.size
+
+    val requiresMultiStoreSurcharge: Boolean get() = extraStoreIds.isNotEmpty()
+}
+
+/**
+ * Each pickup stop on a transporter run.
+ */
+data class PickupStop(
+    val store: Store,
+    val readyInMinutes: Int
+)
+
+/**
+ * Ticket surfaced on the Jobs board.
+ */
+data class JobTicket(
+    val id: String,
+    val orderId: String,
+    val pickups: List<PickupStop>,
+    val dropOff: Address,
+    val method: DeliveryMethod,
+    val payoutKobo: Long,
+    val state: JobState,
+    val assignedTransporterId: String? = null,
+    val lastLocationPingAt: Instant? = null
+) {
+    val isClaimed: Boolean get() = assignedTransporterId != null
+
+    val isActive: Boolean get() = state == JobState.CLAIMED || state == JobState.EN_ROUTE
+}

--- a/data/Repo.kt
+++ b/data/Repo.kt
@@ -1,0 +1,249 @@
+package data
+
+import java.time.Instant
+import java.util.UUID
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Central in-memory repository that feeds the UI. All state containers sit here so
+ * screens can share a single source of truth during the MVP cycle.
+ */
+object Repo {
+    private const val EXTRA_STORE_SURCHARGE_KOBO: Long = 50000L // ₦500
+
+    private val yabaAddress = Address(
+        label = "Tejuosho Ultra Modern Market, Yaba",
+        latitude = 6.5079,
+        longitude = 3.3711
+    )
+    private val ojotaAddress = Address(
+        label = "Ojota New Garage Market",
+        latitude = 6.5882,
+        longitude = 3.3869
+    )
+    private val lekkiAddress = Address(
+        label = "Lekki Phase 1 Farmers Market",
+        latitude = 6.4402,
+        longitude = 3.4832
+    )
+
+    private val storeCatalog = listOf(
+        Store(
+            id = "store_grocer_jola",
+            name = "Jola's Groceries",
+            category = "Groceries",
+            pickupAddress = yabaAddress
+        ),
+        Store(
+            id = "store_farmers_green",
+            name = "Green Harvest Stall",
+            category = "Fresh Produce",
+            pickupAddress = ojotaAddress
+        ),
+        Store(
+            id = "store_readymeals_spice",
+            name = "Spice Route Kitchen",
+            category = "Ready Meals",
+            pickupAddress = lekkiAddress
+        )
+    )
+
+    private val productCatalog = listOf(
+        Product(
+            id = "prod_ofada_rice",
+            storeId = "store_grocer_jola",
+            name = "Ofada Rice (2kg)",
+            unitPriceKobo = 520_00L,
+            unitLabel = "bag"
+        ),
+        Product(
+            id = "prod_palm_oil",
+            storeId = "store_grocer_jola",
+            name = "Fresh Palm Oil (1L)",
+            unitPriceKobo = 300_00L,
+            unitLabel = "bottle"
+        ),
+        Product(
+            id = "prod_ugwu_bundle",
+            storeId = "store_farmers_green",
+            name = "Ugu Leaf Bundle",
+            unitPriceKobo = 120_00L,
+            unitLabel = "bundle"
+        ),
+        Product(
+            id = "prod_pepper_mix",
+            storeId = "store_farmers_green",
+            name = "Pepper Mix Basket",
+            unitPriceKobo = 95_00L,
+            unitLabel = "basket"
+        ),
+        Product(
+            id = "prod_jollof_bowl",
+            storeId = "store_readymeals_spice",
+            name = "Smoky Party Jollof",
+            unitPriceKobo = 250_00L,
+            unitLabel = "bowl"
+        ),
+        Product(
+            id = "prod_moi_moi_pack",
+            storeId = "store_readymeals_spice",
+            name = "Moi Moi Family Pack",
+            unitPriceKobo = 185_00L,
+            unitLabel = "pack"
+        )
+    )
+
+    private val productIndex = productCatalog.associateBy(Product::id)
+    private val storeIndex = storeCatalog.associateBy(Store::id)
+
+    val stores: List<Store> = storeCatalog
+    val products: List<Product> = productCatalog
+    val productsByStore: Map<String, List<Product>> = productCatalog.groupBy(Product::storeId)
+
+    val cartState = MutableStateFlow(Cart())
+    val ordersState = MutableStateFlow<List<Order>>(emptyList())
+    val jobTicketsState = MutableStateFlow<List<JobTicket>>(emptyList())
+
+    fun clearCart() {
+        cartState.value = Cart(deliveryMethod = cartState.value.deliveryMethod)
+    }
+
+    fun setDeliveryMethod(method: DeliveryMethod) {
+        cartState.update { it.copy(deliveryMethod = method) }
+    }
+
+    fun setDropOffAddress(address: Address) {
+        cartState.update { it.copy(dropOffAddress = address) }
+    }
+
+    fun toggleExtraStoreAcceptance(storeId: String) {
+        cartState.update { it.toggleSurchargeAcceptance(storeId) }
+    }
+
+    fun addToCart(productId: String, quantity: Int = 1) {
+        val product = productIndex[productId] ?: return
+        cartState.update { current ->
+            val existing = current.items.firstOrNull { it.product.id == productId }
+            val newQuantity = (existing?.quantity ?: 0) + quantity
+            current.upsertLine(product, newQuantity)
+        }
+    }
+
+    fun setCartQuantity(productId: String, quantity: Int) {
+        val product = productIndex[productId] ?: return
+        if (quantity <= 0) {
+            removeFromCart(productId)
+            return
+        }
+        cartState.update { current -> current.upsertLine(product, quantity) }
+    }
+
+    fun removeFromCart(productId: String) {
+        cartState.update { current -> current.removeLine(productId) }
+    }
+
+    fun pendingSurchargeStoreIds(): Set<String> = cartState.value.pendingAcceptanceStoreIds
+
+    fun computedTotals(): CartTotals = with(cartState.value) {
+        CartTotals(
+            subtotalKobo = subtotalKobo,
+            deliveryFeeKobo = deliveryFeeKobo(),
+            surchargeKobo = surchargeKobo(EXTRA_STORE_SURCHARGE_KOBO),
+            totalKobo = totalKobo(EXTRA_STORE_SURCHARGE_KOBO)
+        )
+    }
+
+    fun placeOrder(): Order? {
+        val currentCart = cartState.value
+        if (currentCart.items.isEmpty()) return null
+        val dropOff = currentCart.dropOffAddress ?: return null
+        if (currentCart.hasPendingSurchargeAcceptance) return null
+
+        val order = Order(
+            id = UUID.randomUUID().toString(),
+            status = OrderStatus.SUBMITTED,
+            items = currentCart.items,
+            storeSequence = currentCart.storeSequence,
+            deliveryMethod = currentCart.deliveryMethod,
+            dropOffAddress = dropOff,
+            subtotalKobo = currentCart.subtotalKobo,
+            deliveryFeeKobo = currentCart.deliveryFeeKobo(),
+            surchargeKobo = currentCart.surchargeKobo(EXTRA_STORE_SURCHARGE_KOBO),
+            totalKobo = currentCart.totalKobo(EXTRA_STORE_SURCHARGE_KOBO),
+            createdAt = Instant.now(),
+            extraStoreIds = currentCart.extraStoreIds
+        )
+
+        ordersState.update { listOf(order) + it }
+        createJobTicketFor(order)
+        clearCart()
+        return order
+    }
+
+    private fun createJobTicketFor(order: Order) {
+        val pickupStops = order.storeSequence.mapNotNull { storeId ->
+            val store = storeIndex[storeId] ?: return@mapNotNull null
+            val readyTime = 10 + (order.items.count { it.product.storeId == storeId } * 3)
+            PickupStop(store = store, readyInMinutes = readyTime)
+        }
+        val ticket = JobTicket(
+            id = "JOB-${order.id.take(8)}",
+            orderId = order.id,
+            pickups = pickupStops,
+            dropOff = order.dropOffAddress,
+            method = order.deliveryMethod,
+            payoutKobo = order.deliveryFeeKobo + order.surchargeKobo,
+            state = JobState.UNCLAIMED
+        )
+        jobTicketsState.update { it + ticket }
+    }
+
+    fun simulateJobClaim(jobId: String, transporterId: String) {
+        jobTicketsState.update { tickets ->
+            tickets.map { ticket ->
+                if (ticket.id == jobId) {
+                    ticket.copy(
+                        state = JobState.CLAIMED,
+                        assignedTransporterId = transporterId,
+                        lastLocationPingAt = Instant.now()
+                    )
+                } else {
+                    ticket
+                }
+            }
+        }
+    }
+
+    fun advanceJob(jobId: String) {
+        jobTicketsState.update { tickets ->
+            tickets.map { ticket ->
+                if (ticket.id == jobId) {
+                    ticket.copy(
+                        state = when (ticket.state) {
+                            JobState.UNCLAIMED -> JobState.CLAIMED
+                            JobState.CLAIMED -> JobState.EN_ROUTE
+                            JobState.EN_ROUTE -> JobState.DELIVERED
+                            JobState.DELIVERED -> JobState.DELIVERED
+                        },
+                        lastLocationPingAt = Instant.now()
+                    )
+                } else {
+                    ticket
+                }
+            }
+        }
+    }
+
+    data class CartTotals(
+        val subtotalKobo: Long,
+        val deliveryFeeKobo: Long,
+        val surchargeKobo: Long,
+        val totalKobo: Long
+    ) {
+        val subtotalNaira: Double get() = subtotalKobo / 100.0
+        val deliveryFeeNaira: Double get() = deliveryFeeKobo / 100.0
+        val surchargeNaira: Double get() = surchargeKobo / 100.0
+        val totalNaira: Double get() = totalKobo / 100.0
+    }
+}

--- a/net/WsConfig.kt
+++ b/net/WsConfig.kt
@@ -1,0 +1,8 @@
+package net
+
+/**
+ * Central place to override the WebSocket endpoint when wiring the real backend.
+ */
+object WsConfig {
+    const val WS_URL: String = "wss://placeholder.oja.jobs/ws"
+}


### PR DESCRIPTION
## Summary
- add delivery models, cart/order helpers, and transporter job ticket types for shared use
- implement an in-memory repo with flows, sample catalogue data, surcharge-aware checkout, and job ticket simulation
- define a shared WebSocket config object for centralising the placeholder endpoint

## Testing
- not run (project has no automated tests yet)


------
https://chatgpt.com/codex/tasks/task_e_68cf043970d483259936b9f0b1c30f32