### PR TITLE
Restore baseline manifest and core app classes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:name=".OjaApp"
+        android:allowBackup="true"
+        android:label="OJA"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_key"/>
+    </application>
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+</manifest>

--- a/app/src/main/java/com/oja/app/MainActivity.kt
+++ b/app/src/main/java/com/oja/app/MainActivity.kt
@@ -1,0 +1,15 @@
+package com.oja.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.ExperimentalMaterial3Api
+import com.oja.app.ui.AppRoot
+
+class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { AppRoot() }
+    }
+}

--- a/app/src/main/java/com/oja/app/OjaApp.kt
+++ b/app/src/main/java/com/oja/app/OjaApp.kt
@@ -1,0 +1,5 @@
+package com.oja.app
+
+import android.app.Application
+
+class OjaApp : Application()

--- a/app/src/main/java/com/oja/app/navigation/Nav.kt
+++ b/app/src/main/java/com/oja/app/navigation/Nav.kt
@@ -1,0 +1,14 @@
+package com.oja.app.navigation
+
+sealed class Route(val path: String) {
+    data object Welcome: Route("welcome")
+    data object Home: Route("home")
+    data object Cart: Route("cart")
+    data object Jobs: Route("jobs")
+    data object Track: Route("track/{orderId}") {
+        fun path(orderId: String) = "track/$orderId"
+    }
+    data object TransporterSignup: Route("transporter")
+    data object VendorSignup: Route("vendor")
+    data object Payments: Route("payments")
+}

--- a/app/src/main/java/com/oja/app/ui/Theme.kt
+++ b/app/src/main/java/com/oja/app/ui/Theme.kt
@@ -1,0 +1,12 @@
+package com.oja.app.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val scheme = darkColorScheme()
+
+@Composable
+fun OjaTheme(content: @Composable () -> Unit) {
+    MaterialTheme(colorScheme = scheme, content = content)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">OJA</string>
+    <string name="google_maps_key">YOUR_MAPS_API_KEY_HERE</string>
+    <string name="welcome_title">Welcome to OJA</string>
+    <string name="welcome_sub">Your neighborhood market—street to doorstep</string>
+</resources>


### PR DESCRIPTION
## Summary
- add the recorded AndroidManifest with OjaApp and MainActivity registrations and required permissions
- restore baseline string resources used by the Compose shell
- reintroduce application, activity, theme, and navigation Kotlin classes with their original packages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf2bbd7fa08325b8fb81f1460d6163