### PR TITLE
Add AppRoot navigation and UI screens

### DIFF
--- a/app/src/main/java/com/oja/app/data/Models.kt
+++ b/app/src/main/java/com/oja/app/data/Models.kt
@@ -1,0 +1,30 @@
+package com.oja.app.data
+
+enum class DeliveryMethod { BICYCLE, BIKE, CAR }
+
+data class Store(val id: String, val name: String)
+data class Product(val id: String, val storeId: String, val name: String, val price: Long)
+
+data class CartItem(val product: Product, val qty: Int)
+data class CartState(
+    val items: List<CartItem> = emptyList(),
+    val acceptedExtraFees: Set<String> = emptySet() // storeId -> accepted
+) {
+    val groupedByStore: Map<String, List<CartItem>> get() = items.groupBy { it.product.storeId }
+    val subtotal: Long get() = items.sumOf { it.product.price * it.qty }
+}
+
+data class Order(val id: String, val storeIds: List<String>, val method: DeliveryMethod, val total: Long)
+
+data class JobTicket(
+    val id: String,
+    val orderId: String,
+    val method: DeliveryMethod,
+    val pickupLat: Double,
+    val pickupLng: Double,
+    val dropLat: Double,
+    val dropLng: Double,
+    val claimedByTransporterId: String? = null
+)
+
+data class TransporterProfile(val id: String, val name: String, val methods: Set<DeliveryMethod>)

--- a/app/src/main/java/com/oja/app/data/Repo.kt
+++ b/app/src/main/java/com/oja/app/data/Repo.kt
@@ -1,0 +1,52 @@
+package com.oja.app.data
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlin.random.Random
+
+object Repo {
+    private val _cart = MutableStateFlow(CartState())
+    val cart: StateFlow<CartState> = _cart
+
+    private val _jobs = MutableStateFlow<List<JobTicket>>(emptyList())
+    val jobs: StateFlow<List<JobTicket>> = _jobs
+
+    private val stores = listOf(
+        Store("s1","Idumota Plastics"),
+        Store("s2","Lekki Grocer"),
+        Store("s3","Ajah Tools")
+    )
+    val products = listOf(
+        Product("p1","s1","Broom", 1200),
+        Product("p2","s2","Indomie Pack", 5000),
+        Product("p3","s3","Spanner", 2500)
+    )
+
+    fun addToCart(p: Product) { _cart.update { it.copy(items = it.items + CartItem(p, 1)) } }
+    fun acceptExtraFeeFor(storeId: String) { _cart.update { it.copy(acceptedExtraFees = it.acceptedExtraFees + storeId) } }
+    fun clearCart() { _cart.value = CartState() }
+
+    fun createOrder(method: DeliveryMethod): Order {
+        val cs = _cart.value
+        val storeIds = cs.groupedByStore.keys.toList()
+        val base = cs.subtotal
+        val extraFee = (storeIds.size - 1).coerceAtLeast(0) * 700 // per extra store
+        val total = base + extraFee
+        val order = Order(id = "o-${Random.nextInt(10000, 99999)}", storeIds, method, total)
+        val jt = JobTicket(
+            id = "j-${Random.nextInt(10000,99999)}",
+            orderId = order.id,
+            method = method,
+            pickupLat = 6.449, pickupLng = 3.602, // Ajah-ish
+            dropLat = 6.453, dropLng = 3.611
+        )
+        _jobs.update { listOf(jt) + it }
+        _cart.value = CartState()
+        return order
+    }
+
+    fun claimJob(jobId: String, transporterId: String) {
+        _jobs.update { list -> list.map { if (it.id == jobId) it.copy(claimedByTransporterId = transporterId) else it } }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/AppRoot.kt
+++ b/app/src/main/java/com/oja/app/ui/AppRoot.kt
@@ -1,0 +1,30 @@
+package com.oja.app.ui
+
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.oja.app.navigation.Route
+import com.oja.app.ui.screens.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppRoot() {
+    OjaTheme {
+        val nav = rememberNavController()
+        NavHost(navController = nav, startDestination = Route.Welcome.path) {
+            composable(Route.Welcome.path) { WelcomeScreen(onStart = { nav.navigate(Route.Home.path) }) }
+            composable(Route.Home.path) { HomeScreen(nav) }
+            composable(Route.Cart.path) { CartScreen(nav) }
+            composable(Route.Jobs.path) { JobsDashboardScreen(nav) }
+            composable(Route.TransporterSignup.path) { TransporterSignupScreen(nav) }
+            composable(Route.VendorSignup.path) { VendorSignupScreen(nav) }
+            composable(Route.Payments.path) { PaymentsScreen(nav) }
+            composable(Route.Track.path) { backStack ->
+                val orderId = backStack.arguments?.getString("orderId").orEmpty()
+                TrackScreen(orderId = orderId, onBack = { nav.popBackStack() })
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -1,0 +1,72 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.*
+import com.oja.app.navigation.Route
+
+@Composable
+fun CartScreen(nav: NavHostController) {
+    val cart by Repo.cart.collectAsState()
+    var method by remember { mutableStateOf(DeliveryMethod.BIKE) }
+    var pendingStoreId by remember { mutableStateOf<String?>(null) }
+
+    val groups = cart.groupedByStore
+    val extraStores = (groups.keys.size - 1).coerceAtLeast(0)
+    val extraFee = extraStores * 700L
+    val needsAccept = groups.keys.any { it !in cart.acceptedExtraFees } && groups.keys.size > 1
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        LazyColumn(Modifier.weight(1f)) {
+            groups.forEach { (storeId, items) ->
+                item { Text("Store: $storeId") }
+                items(items.size) { i ->
+                    val it = items[i]
+                    Text("${it.product.name} x${it.qty} — ₦${it.product.price}")
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button({ method = DeliveryMethod.BICYCLE }) { Text("Bicycle") }
+            Button({ method = DeliveryMethod.BIKE }) { Text("Bike") }
+            Button({ method = DeliveryMethod.CAR }) { Text("Car") }
+        }
+        Spacer(Modifier.height(8.dp))
+        Text("Subtotal: ₦${cart.subtotal}")
+        if (extraStores > 0) Text("Extra store fee: ₦$extraFee")
+        Spacer(Modifier.height(8.dp))
+        Button({
+            if (needsAccept) {
+                pendingStoreId = groups.keys.first { it !in cart.acceptedExtraFees }
+            } else {
+                val order = Repo.createOrder(method)
+                nav.navigate(Route.Track.path(order.id))
+            }
+        }, enabled = cart.items.isNotEmpty()) { Text("Checkout") }
+    }
+
+    val sid = pendingStoreId
+    if (sid != null) {
+        AlertDialog(
+            onDismissRequest = { pendingStoreId = null },
+            title = { Text("Extra logistics cost") },
+            text = { Text("Adding items from $sid adds courier cost. Accept?") },
+            confirmButton = {
+                TextButton({
+                    Repo.acceptExtraFeeFor(sid)
+                    pendingStoreId = null
+                }) { Text("Accept") }
+            },
+            dismissButton = { TextButton({ pendingStoreId = null }) { Text("Cancel") } }
+        )
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
@@ -1,0 +1,38 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+
+@Composable
+fun HomeScreen(nav: NavHostController) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button({ nav.navigate(Route.Cart.path) }) { Text("Cart") }
+            Button({ nav.navigate(Route.Jobs.path) }) { Text("Jobs") }
+            Button({ nav.navigate(Route.TransporterSignup.path) }) { Text("Be a Transporter") }
+        }
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(Repo.products.size) { idx ->
+                val p = Repo.products[idx]
+                Card(Modifier.fillMaxWidth().padding(2.dp)) {
+                    Column(Modifier.padding(12.dp)) {
+                        Text(p.name)
+                        Text("₦${p.price}")
+                        Spacer(Modifier.height(8.dp))
+                        Button({ Repo.addToCart(p) }) { Text("Add to Cart") }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
@@ -1,0 +1,60 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.JobTicket
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun JobsDashboardScreen(nav: NavHostController) {
+    val jobs by Repo.jobs.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(jobs.size) {
+        // simulate auto-updating: new purchases add to the top elsewhere in Repo
+    }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Unclaimed Deliveries")
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(jobs.size) { i ->
+                val j = jobs[i]
+                JobCard(j, onTrack = { nav.navigate(Route.Track.path(j.orderId)) }, onClaim = {
+                    scope.launch {
+                        delay(300)
+                        Repo.claimJob(j.id, transporterId = "tx-001")
+                    }
+                })
+            }
+        }
+    }
+}
+
+@Composable
+private fun JobCard(j: JobTicket, onTrack: () -> Unit, onClaim: () -> Unit) {
+    Card(Modifier.fillMaxWidth().clickable(onClick = onTrack)) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Job ${j.id} • ${j.method}")
+            Text("Order ${j.orderId}")
+            val status = if (j.claimedByTransporterId == null) "Unclaimed" else "Claimed by ${j.claimedByTransporterId}"
+            Text(status)
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onTrack) { Text("Track") }
+                if (j.claimedByTransporterId == null) Button(onClaim) { Text("Claim") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/PaymentsScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/PaymentsScreen.kt
@@ -1,0 +1,20 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun PaymentsScreen(nav: NavHostController) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Payments (Test Mode)")
+        Spacer(Modifier.height(8.dp))
+        Button({ /* trigger Paystack PaymentSheet with server access_code */ }) { Text("Pay with Paystack") }
+        Spacer(Modifier.height(8.dp))
+        Button({ /* open Flutterwave Drop-In */ }) { Text("Pay with Flutterwave") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
@@ -1,0 +1,61 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.maps.android.compose.*
+import com.oja.app.data.Repo
+import kotlinx.coroutines.delay
+import kotlin.math.min
+
+@Composable
+fun TrackScreen(orderId: String, onBack: () -> Unit) {
+    val job = Repo.jobs.value.firstOrNull { it.orderId == orderId }
+    Column(Modifier.fillMaxSize()) {
+        if (job == null) {
+            Text("No tracking for $orderId")
+            Button(onBack) { Text("Back") }
+            return
+        }
+
+        val start = com.google.android.gms.maps.model.LatLng(job.pickupLat, job.pickupLng)
+        val end = com.google.android.gms.maps.model.LatLng(job.dropLat, job.dropLng)
+        val cameraPositionState = rememberCameraPositionState {
+            position = com.google.android.gms.maps.model.CameraPosition.fromLatLngZoom(start, 13f)
+        }
+
+        var progress by remember { mutableStateOf(0f) }
+        LaunchedEffect(orderId) {
+            while (progress < 1f) {
+                delay(800)
+                progress = min(1f, progress + 0.08f)
+            }
+        }
+
+        val current = com.google.android.gms.maps.model.LatLng(
+            start.latitude + (end.latitude - start.latitude) * progress,
+            start.longitude + (end.longitude - start.longitude) * progress
+        )
+
+        if (com.google.android.libraries.maps.BuildConfig.VERSION_NAME != null) {
+            GoogleMap(
+                modifier = Modifier.weight(1f),
+                cameraPositionState = cameraPositionState
+            ) {
+                Polyline(points = listOf(start, end))
+                Marker(state = rememberMarkerState(position = start), title = "Pickup")
+                Marker(state = rememberMarkerState(position = end), title = "Dropoff")
+                Marker(state = rememberMarkerState(position = current), title = "Courier")
+            }
+        } else {
+            Box(Modifier.weight(1f)) { Text("Map placeholder (add Maps API key)") }
+        }
+        Row(Modifier.fillMaxWidth().padding(12.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onBack) { Text("Back") }
+            Text("Progress: ${(progress * 100).toInt()}%")
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
@@ -1,0 +1,28 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.DeliveryMethod
+
+@Composable
+fun TransporterSignupScreen(nav: NavHostController) {
+    var name by remember { mutableStateOf("") }
+    var bike by remember { mutableStateOf(true) }
+    var bicycle by remember { mutableStateOf(false) }
+    var car by remember { mutableStateOf(false) }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Transporter Registration")
+        Row { Checkbox(bicycle, { bicycle = it }); Text("Bicycle") }
+        Row { Checkbox(bike, { bike = it }); Text("Bike") }
+        Row { Checkbox(car, { car = it }); Text("Car") }
+        Spacer(Modifier.height(8.dp))
+        Button({ nav.popBackStack() }) { Text("Submit") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/VendorSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/VendorSignupScreen.kt
@@ -1,0 +1,18 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun VendorSignupScreen(nav: NavHostController) {
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Vendor Onboarding")
+        Spacer(Modifier.height(8.dp))
+        Button({ nav.popBackStack() }) { Text("Submit") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
@@ -1,0 +1,28 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.oja.app.R
+
+@Composable
+fun WelcomeScreen(onStart: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(16.dp))
+        Text("Welcome to OJA", textAlign = TextAlign.Center)
+        // Placeholder hero; swap with generated “field agents” artwork later.
+        Image(painterResource(id = R.drawable.ic_launcher_foreground), contentDescription = "Agents")
+        Button(onClick = onStart, modifier = Modifier.fillMaxWidth()) { Text("Enter Market") }
+    }
+}


### PR DESCRIPTION
## Summary
- add AppRoot composable hosting the Material 3 navigation graph
- implement Welcome, Home, Cart, Jobs, Track, Transporter, Vendor, and Payments screens from the product brief
- include lightweight in-memory data models and repository used by the UI

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2c54de1883258eca27331fc9c234