### PR TITLE
Add lazy items import to Compose screens

### DIFF
--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -2,6 +2,7 @@ package com.oja.app.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text

--- a/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
@@ -2,6 +2,7 @@ package com.oja.app.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text

--- a/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
@@ -3,6 +3,7 @@ package com.oja.app.ui.screens
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text


### PR DESCRIPTION
## Summary
- add LazyColumn items import to the home, jobs dashboard, and cart screens so the items builders resolve

## Testing
- ./gradlew app:compileDebugKotlin *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf344f9f5c832580dbf7bd9557481b