### PR TITLE
Add missing LazyColumn item import

### DIFF
--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -2,6 +2,7 @@ package com.oja.app.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.item
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button


### PR DESCRIPTION
## Summary
- add the missing LazyColumn `item` extension import in the cart screen so the composable scope resolves correctly

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf36317fec83258b2839434227a8fc