### PR TITLE
Fix cart screen item variable naming

### DIFF
--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -28,10 +28,10 @@ fun CartScreen(nav: NavHostController) {
 
     Column(Modifier.fillMaxSize().padding(16.dp)) {
         LazyColumn(Modifier.weight(1f)) {
-            groups.forEach { (storeId, items) ->
+            groups.forEach { (storeId, storeItems) ->
                 item { Text("Store: $storeId") }
-                items(items.size) { i ->
-                    val it = items[i]
+                items(storeItems.size) { i ->
+                    val it = storeItems[i]
                     Text("${it.product.name} x${it.qty} — ₦${it.product.price}")
                 }
             }


### PR DESCRIPTION
## Summary
- rename the grouped cart item variable in `CartScreen` to avoid shadowing the Compose `items` builder

## Testing
- `./gradlew :app:assemble` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf36c3015c8325b4938d73b177803b