### PR TITLE
Add missing lazy item imports for Compose screens

### DIFF
--- a/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
@@ -2,6 +2,7 @@ package com.oja.app.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.item
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card

--- a/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
@@ -3,6 +3,7 @@ package com.oja.app.ui.screens
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.item
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card


### PR DESCRIPTION
## Summary
- add the LazyColumn item import to the home and jobs dashboards
- ensure the cart screen already includes both lazy item imports

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf38bc13248325824b8af4f5c08332