### PR TITLE
Rename store items variable in cart screen

### DIFF
--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -31,8 +31,8 @@ fun CartScreen(nav: NavHostController) {
             groups.forEach { (storeId, storeItems) ->
                 item { Text("Store: $storeId") }
                 items(storeItems.size) { i ->
-                    val it = storeItems[i]
-                    Text("${it.product.name} x${it.qty} — ₦${it.product.price}")
+                    val storeItem = storeItems[i]
+                    Text("${storeItem.product.name} x${storeItem.qty} — ₦${storeItem.product.price}")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- avoid shadowing LazyColumn builder names by using a distinct storeItems variable in the cart screen loop
- update the lazy list item binding to use the renamed variable while keeping the UI text intact

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf39aa6a888325bfddcff1cf62695e