### PR TITLE
Restore Compose screen wiring and placeholder assets

### DIFF
--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -28,11 +28,11 @@ fun CartScreen(nav: NavHostController) {
 
     Column(Modifier.fillMaxSize().padding(16.dp)) {
         LazyColumn(Modifier.weight(1f)) {
-            groups.forEach { (storeId, storeItems) ->
+            groups.forEach { (storeId, items) ->
                 item { Text("Store: $storeId") }
-                items(storeItems.size) { i ->
-                    val storeItem = storeItems[i]
-                    Text("${storeItem.product.name} x${storeItem.qty} — ₦${storeItem.product.price}")
+                items(items.size) { i ->
+                    val it = items[i]
+                    Text("${it.product.name} x${it.qty} — ₦${it.product.price}")
                 }
             }
         }

--- a/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
@@ -2,7 +2,6 @@ package com.oja.app.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.item
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card

--- a/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
@@ -3,7 +3,6 @@ package com.oja.app.ui.screens
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.item
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:scaleX="0.5" android:scaleY="0.5" android:translateX="27" android:translateY="27">
+        <path
+            android:fillColor="#2ECC71"
+            android:pathData="M54,0A54,54 0 1,1 0,54 54,54 0 0,1 54,0Z"/>
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M30,40h12l6,-20 12,40h-12l-6,20z"/>
+    </group>
+</vector>


### PR DESCRIPTION
## Summary
- realign the cart, home, and jobs dashboard composables with the recorded navigation flow and state usage
- add the launcher foreground vector drawable referenced by the welcome screen placeholder artwork

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK not installed in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2943254083259aa3e0d00c9789af