### PR TITLE
Initialize Compose application scaffolding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,86 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.oja.app"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.oja.app"
+        minSdk = 23
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+
+        vectorDrawables { useSupportLibrary = true }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug { isMinifyEnabled = false }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions { jvmTarget = "17" }
+
+    buildFeatures { compose = true }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+
+    packaging {
+        resources.excludes += setOf(
+            "/META-INF/{AL2.0,LGPL2.1}",
+            "META-INF/INDEX.LIST"
+        )
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2025.08.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
+    implementation("androidx.navigation:navigation-compose:2.8.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+
+    implementation("com.google.maps.android:maps-compose:6.7.1")
+    implementation("com.google.android.gms:play-services-maps:19.0.0")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
+
+    implementation("io.ktor:ktor-client-okhttp:3.2.3")
+    implementation("io.ktor:ktor-client-websockets:3.2.3")
+    implementation("io.ktor:ktor-client-content-negotiation:3.2.3")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.2.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+
+    implementation("io.coil-kt:coil-compose:2.7.0")
+
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
+    implementation("com.google.zxing:core:3.5.3")
+
+    implementation("com.paystack.android:paystack-ui:0.0.10")
+    implementation("com.github.flutterwave.rave-android:rave_android:2.2.1")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
     kotlinOptions { jvmTarget = "17" }
 
     buildFeatures { compose = true }
-    composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+    composeOptions { kotlinCompilerExtensionVersion = "2.0.0" }
 
     packaging {
         resources.excludes += setOf(

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Keep default settings; add rules as needed for release builds.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:name=".OjaApp"
+        android:allowBackup="true"
+        android:label="OJA"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_key" />
+    </application>
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
         android:name=".OjaApp"
         android:allowBackup="true"
         android:label="OJA"
+        android:icon="@mipmap/ic_launcher"
         android:theme="@style/Theme.Material3.DayNight.NoActionBar">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!--
+            WARNING: You must replace the placeholder value in @string/google_maps_key
+            with your actual Google Maps API key. The app will fail to load Maps
+            functionality if the placeholder (e.g., "YOUR_MAPS_API_KEY_HERE") is used.
+            See strings.xml for details.
+        -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/google_maps_key" />

--- a/app/src/main/java/com/oja/app/MainActivity.kt
+++ b/app/src/main/java/com/oja/app/MainActivity.kt
@@ -1,0 +1,15 @@
+package com.oja.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.ExperimentalMaterial3Api
+import com.oja.app.ui.AppRoot
+
+class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent { AppRoot() }
+    }
+}

--- a/app/src/main/java/com/oja/app/MainActivity.kt
+++ b/app/src/main/java/com/oja/app/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import com.oja.app.ui.AppRoot
 
 class MainActivity : ComponentActivity() {
-    @OptIn(ExperimentalMaterial3Api::class)
+    
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent { AppRoot() }

--- a/app/src/main/java/com/oja/app/OjaApp.kt
+++ b/app/src/main/java/com/oja/app/OjaApp.kt
@@ -1,0 +1,5 @@
+package com.oja.app
+
+import android.app.Application
+
+class OjaApp : Application()

--- a/app/src/main/java/com/oja/app/data/Models.kt
+++ b/app/src/main/java/com/oja/app/data/Models.kt
@@ -1,0 +1,30 @@
+package com.oja.app.data
+
+enum class DeliveryMethod { BICYCLE, BIKE, CAR }
+
+data class Store(val id: String, val name: String)
+data class Product(val id: String, val storeId: String, val name: String, val price: Long)
+
+data class CartItem(val product: Product, val qty: Int)
+data class CartState(
+    val items: List<CartItem> = emptyList(),
+    val acceptedExtraFees: Set<String> = emptySet()
+) {
+    val groupedByStore: Map<String, List<CartItem>> get() = items.groupBy { it.product.storeId }
+    val subtotal: Long get() = items.sumOf { it.product.price * it.qty }
+}
+
+data class Order(val id: String, val storeIds: List<String>, val method: DeliveryMethod, val total: Long)
+
+data class JobTicket(
+    val id: String,
+    val orderId: String,
+    val method: DeliveryMethod,
+    val pickupLat: Double,
+    val pickupLng: Double,
+    val dropLat: Double,
+    val dropLng: Double,
+    val claimedByTransporterId: String? = null
+)
+
+data class TransporterProfile(val id: String, val name: String, val methods: Set<DeliveryMethod>)

--- a/app/src/main/java/com/oja/app/data/Repo.kt
+++ b/app/src/main/java/com/oja/app/data/Repo.kt
@@ -1,0 +1,54 @@
+package com.oja.app.data
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlin.random.Random
+
+object Repo {
+    private val _cart = MutableStateFlow(CartState())
+    val cart: StateFlow<CartState> = _cart
+
+    private val _jobs = MutableStateFlow<List<JobTicket>>(emptyList())
+    val jobs: StateFlow<List<JobTicket>> = _jobs
+
+    private val stores = listOf(
+        Store("s1", "Idumota Plastics"),
+        Store("s2", "Lekki Grocer"),
+        Store("s3", "Ajah Tools")
+    )
+    val products = listOf(
+        Product("p1", "s1", "Broom", 1200),
+        Product("p2", "s2", "Indomie Pack", 5000),
+        Product("p3", "s3", "Spanner", 2500)
+    )
+
+    fun addToCart(p: Product) { _cart.update { it.copy(items = it.items + CartItem(p, 1)) } }
+    fun acceptExtraFeeFor(storeId: String) { _cart.update { it.copy(acceptedExtraFees = it.acceptedExtraFees + storeId) } }
+    fun clearCart() { _cart.value = CartState() }
+
+    fun createOrder(method: DeliveryMethod): Order {
+        val cs = _cart.value
+        val storeIds = cs.groupedByStore.keys.toList()
+        val base = cs.subtotal
+        val extraFee = (storeIds.size - 1).coerceAtLeast(0) * 700
+        val total = base + extraFee
+        val order = Order(id = "o-${'$'}{Random.nextInt(10000, 99999)}", storeIds, method, total)
+        val jt = JobTicket(
+            id = "j-${'$'}{Random.nextInt(10000, 99999)}",
+            orderId = order.id,
+            method = method,
+            pickupLat = 6.449,
+            pickupLng = 3.602,
+            dropLat = 6.453,
+            dropLng = 3.611
+        )
+        _jobs.update { listOf(jt) + it }
+        _cart.value = CartState()
+        return order
+    }
+
+    fun claimJob(jobId: String, transporterId: String) {
+        _jobs.update { list -> list.map { if (it.id == jobId) it.copy(claimedByTransporterId = transporterId) else it } }
+    }
+}

--- a/app/src/main/java/com/oja/app/data/Repo.kt
+++ b/app/src/main/java/com/oja/app/data/Repo.kt
@@ -31,7 +31,7 @@ object Repo {
         val cs = _cart.value
         val storeIds = cs.groupedByStore.keys.toList()
         val base = cs.subtotal
-        val extraFee = (storeIds.size - 1).coerceAtLeast(0) * 700
+        val extraFee = (storeIds.size - 1).coerceAtLeast(0) * 700L
         val total = base + extraFee
         val order = Order(id = "o-${'$'}{Random.nextInt(10000, 99999)}", storeIds, method, total)
         val jt = JobTicket(

--- a/app/src/main/java/com/oja/app/navigation/Nav.kt
+++ b/app/src/main/java/com/oja/app/navigation/Nav.kt
@@ -1,0 +1,14 @@
+package com.oja.app.navigation
+
+sealed class Route(val path: String) {
+    data object Welcome : Route("welcome")
+    data object Home : Route("home")
+    data object Cart : Route("cart")
+    data object Jobs : Route("jobs")
+    data object Track : Route("track/{orderId}") {
+        fun path(orderId: String) = "track/$orderId"
+    }
+    data object TransporterSignup : Route("transporter")
+    data object VendorSignup : Route("vendor")
+    data object Payments : Route("payments")
+}

--- a/app/src/main/java/com/oja/app/net/WsConfig.kt
+++ b/app/src/main/java/com/oja/app/net/WsConfig.kt
@@ -1,0 +1,6 @@
+package com.oja.app.net
+
+object WsConfig {
+    // Replace with your backend when ready. Leave as-is; UI will simulate.
+    const val WS_URL = "wss://example.com/oja/ws"
+}

--- a/app/src/main/java/com/oja/app/ui/AppRoot.kt
+++ b/app/src/main/java/com/oja/app/ui/AppRoot.kt
@@ -1,0 +1,37 @@
+package com.oja.app.ui
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.oja.app.navigation.Route
+import com.oja.app.ui.screens.CartScreen
+import com.oja.app.ui.screens.HomeScreen
+import com.oja.app.ui.screens.JobsDashboardScreen
+import com.oja.app.ui.screens.PaymentsScreen
+import com.oja.app.ui.screens.TrackScreen
+import com.oja.app.ui.screens.TransporterSignupScreen
+import com.oja.app.ui.screens.VendorSignupScreen
+import com.oja.app.ui.screens.WelcomeScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppRoot() {
+    OjaTheme {
+        val nav = rememberNavController()
+        NavHost(navController = nav, startDestination = Route.Welcome.path) {
+            composable(Route.Welcome.path) { WelcomeScreen(onStart = { nav.navigate(Route.Home.path) }) }
+            composable(Route.Home.path) { HomeScreen(nav) }
+            composable(Route.Cart.path) { CartScreen(nav) }
+            composable(Route.Jobs.path) { JobsDashboardScreen(nav) }
+            composable(Route.TransporterSignup.path) { TransporterSignupScreen(nav) }
+            composable(Route.VendorSignup.path) { VendorSignupScreen(nav) }
+            composable(Route.Payments.path) { PaymentsScreen(nav) }
+            composable(Route.Track.path) { backStackEntry ->
+                val orderId = backStackEntry.arguments?.getString("orderId").orEmpty()
+                TrackScreen(orderId = orderId, onBack = { nav.popBackStack() })
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/AppRoot.kt
+++ b/app/src/main/java/com/oja/app/ui/AppRoot.kt
@@ -28,7 +28,7 @@ fun AppRoot() {
             composable(Route.TransporterSignup.path) { TransporterSignupScreen(nav) }
             composable(Route.VendorSignup.path) { VendorSignupScreen(nav) }
             composable(Route.Payments.path) { PaymentsScreen(nav) }
-            composable(Route.Track.path) { backStackEntry ->
+            composable("track/{orderId}") { backStackEntry ->
                 val orderId = backStackEntry.arguments?.getString("orderId").orEmpty()
                 TrackScreen(orderId = orderId, onBack = { nav.popBackStack() })
             }

--- a/app/src/main/java/com/oja/app/ui/Theme.kt
+++ b/app/src/main/java/com/oja/app/ui/Theme.kt
@@ -1,0 +1,12 @@
+package com.oja.app.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val scheme = darkColorScheme()
+
+@Composable
+fun OjaTheme(content: @Composable () -> Unit) {
+    MaterialTheme(colorScheme = scheme, content = content)
+}

--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -1,0 +1,99 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.DeliveryMethod
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+
+@Composable
+fun CartScreen(nav: NavHostController) {
+    val cart by Repo.cart.collectAsState()
+    var method by remember { mutableStateOf(DeliveryMethod.BIKE) }
+    var pendingStoreId by remember { mutableStateOf<String?>(null) }
+
+    val groups = cart.groupedByStore
+    val extraStores = (groups.keys.size - 1).coerceAtLeast(0)
+    val extraFee = extraStores * 700L
+    val needsAccept = groups.keys.any { it !in cart.acceptedExtraFees } && groups.keys.size > 1
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        LazyColumn(Modifier.weight(1f)) {
+            groups.forEach { (storeId, items) ->
+                item { Text("Store: ${'$'}storeId") }
+                items(items.size) { index ->
+                    val cartItem = items[index]
+                    Text("${'$'}{cartItem.product.name} x${'$'}{cartItem.qty} — ₦${'$'}{cartItem.product.price}")
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { method = DeliveryMethod.BICYCLE }) { Text("Bicycle") }
+            Button(onClick = { method = DeliveryMethod.BIKE }) { Text("Bike") }
+            Button(onClick = { method = DeliveryMethod.CAR }) { Text("Car") }
+        }
+        Spacer(Modifier.height(8.dp))
+        Text("Subtotal: ₦${'$'}{cart.subtotal}")
+        if (extraStores > 0) {
+            Text("Extra store fee: ₦${'$'}extraFee")
+        }
+        Spacer(Modifier.height(8.dp))
+        Button(
+            onClick = {
+                if (needsAccept) {
+                    pendingStoreId = groups.keys.first { it !in cart.acceptedExtraFees }
+                } else {
+                    val order = Repo.createOrder(method)
+                    nav.navigate(Route.Track.path(order.id))
+                }
+            },
+            enabled = cart.items.isNotEmpty()
+        ) { Text("Checkout") }
+    }
+
+    val sid = pendingStoreId
+    if (sid != null) {
+        AlertDialog(
+            onDismissRequest = { pendingStoreId = null },
+            title = { Text("Extra logistics cost") },
+            text = { Text("Adding items from ${'$'}sid adds courier cost. Accept?") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        Repo.acceptExtraFeeFor(sid)
+                        pendingStoreId = null
+                    }
+                ) { Text("Accept") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingStoreId = null }) { Text("Cancel") }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/CartScreen.kt
@@ -46,9 +46,8 @@ fun CartScreen(nav: NavHostController) {
         LazyColumn(Modifier.weight(1f)) {
             groups.forEach { (storeId, items) ->
                 item { Text("Store: ${'$'}storeId") }
-                items(items.size) { index ->
-                    val cartItem = items[index]
-                    Text("${'$'}{cartItem.product.name} x${'$'}{cartItem.qty} — ₦${'$'}{cartItem.product.price}")
+                items(items) { cartItem ->
+                    Text("${cartItem.product.name} x${cartItem.qty} — ₦${cartItem.product.price}")
                 }
             }
         }

--- a/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
@@ -1,0 +1,57 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+
+@Composable
+fun HomeScreen(nav: NavHostController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(onClick = { nav.navigate(Route.Cart.path) }) { Text("Cart") }
+            Button(onClick = { nav.navigate(Route.Jobs.path) }) { Text("Jobs") }
+            Button(onClick = { nav.navigate(Route.TransporterSignup.path) }) { Text("Be a Transporter") }
+        }
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(Repo.products.size) { idx ->
+                val product = Repo.products[idx]
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(2.dp)
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+                        Text(product.name)
+                        Text("₦${'$'}{product.price}")
+                        Spacer(Modifier.height(8.dp))
+                        Button(onClick = { Repo.addToCart(product) }) { Text("Add to Cart") }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/HomeScreen.kt
@@ -37,8 +37,7 @@ fun HomeScreen(nav: NavHostController) {
         }
         Spacer(Modifier.height(8.dp))
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            items(Repo.products.size) { idx ->
-                val product = Repo.products[idx]
+            items(Repo.products) { product ->
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/JobsDashboardScreen.kt
@@ -1,0 +1,80 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.JobTicket
+import com.oja.app.data.Repo
+import com.oja.app.navigation.Route
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun JobsDashboardScreen(nav: NavHostController) {
+    val jobs by Repo.jobs.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text("Unclaimed Deliveries")
+        Spacer(Modifier.height(8.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(jobs) { job ->
+                JobCard(
+                    job = job,
+                    onTrack = { nav.navigate(Route.Track.path(job.orderId)) },
+                    onClaim = {
+                        scope.launch {
+                            delay(300)
+                            Repo.claimJob(job.id, transporterId = "tx-001")
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun JobCard(job: JobTicket, onTrack: () -> Unit, onClaim: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onTrack)
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Job ${'$'}{job.id} • ${'$'}{job.method}")
+            Text("Order ${'$'}{job.orderId}")
+            val status = if (job.claimedByTransporterId == null) "Unclaimed" else "Claimed by ${'$'}{job.claimedByTransporterId}"
+            Text(status)
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onTrack) { Text("Track") }
+                if (job.claimedByTransporterId == null) {
+                    Button(onClick = onClaim) { Text("Claim") }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/PaymentsScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/PaymentsScreen.kt
@@ -1,0 +1,28 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun PaymentsScreen(nav: NavHostController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text("Payments (Test Mode)")
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { /* trigger Paystack PaymentSheet with server access_code */ }) { Text("Pay with Paystack") }
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { /* open Flutterwave Drop-In */ }) { Text("Pay with Flutterwave") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
@@ -1,0 +1,82 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.Polyline
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberMarkerState
+import com.oja.app.data.Repo
+import kotlinx.coroutines.delay
+import kotlin.math.min
+
+@Composable
+fun TrackScreen(orderId: String, onBack: () -> Unit) {
+    val job = Repo.jobs.value.firstOrNull { it.orderId == orderId }
+    Column(Modifier.fillMaxSize()) {
+        if (job == null) {
+            Text("No tracking for ${'$'}orderId")
+            Button(onClick = onBack) { Text("Back") }
+            return
+        }
+
+        val start = com.google.android.gms.maps.model.LatLng(job.pickupLat, job.pickupLng)
+        val end = com.google.android.gms.maps.model.LatLng(job.dropLat, job.dropLng)
+        val cameraPositionState = rememberCameraPositionState {
+            position = com.google.android.gms.maps.model.CameraPosition.fromLatLngZoom(start, 13f)
+        }
+
+        var progress by remember { mutableStateOf(0f) }
+        LaunchedEffect(orderId) {
+            while (progress < 1f) {
+                delay(800)
+                progress = min(1f, progress + 0.08f)
+            }
+        }
+
+        val current = com.google.android.gms.maps.model.LatLng(
+            start.latitude + (end.latitude - start.latitude) * progress,
+            start.longitude + (end.longitude - start.longitude) * progress
+        )
+
+        if (com.google.android.libraries.maps.BuildConfig.VERSION_NAME != null) {
+            GoogleMap(
+                modifier = Modifier.weight(1f),
+                cameraPositionState = cameraPositionState
+            ) {
+                Polyline(points = listOf(start, end))
+                Marker(state = rememberMarkerState(position = start), title = "Pickup")
+                Marker(state = rememberMarkerState(position = end), title = "Dropoff")
+                Marker(state = rememberMarkerState(position = current), title = "Courier")
+            }
+        } else {
+            Box(Modifier.weight(1f)) { Text("Map placeholder (add Maps API key)") }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(onClick = onBack) { Text("Back") }
+            Text("Progress: ${(progress * 100).toInt()}%")
+        }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TrackScreen.kt
@@ -30,13 +30,12 @@ import kotlin.math.min
 @Composable
 fun TrackScreen(orderId: String, onBack: () -> Unit) {
     val job = Repo.jobs.value.firstOrNull { it.orderId == orderId }
+    if (job == null) {
+        Text("No tracking for ${'$'}orderId")
+        Button(onClick = onBack) { Text("Back") }
+        return
+    }
     Column(Modifier.fillMaxSize()) {
-        if (job == null) {
-            Text("No tracking for ${'$'}orderId")
-            Button(onClick = onBack) { Text("Back") }
-            return
-        }
-
         val start = com.google.android.gms.maps.model.LatLng(job.pickupLat, job.pickupLng)
         val end = com.google.android.gms.maps.model.LatLng(job.dropLat, job.dropLng)
         val cameraPositionState = rememberCameraPositionState {

--- a/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
@@ -1,0 +1,41 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.oja.app.data.DeliveryMethod
+
+@Composable
+fun TransporterSignupScreen(nav: NavHostController) {
+    var name by remember { mutableStateOf("") }
+    var bike by remember { mutableStateOf(true) }
+    var bicycle by remember { mutableStateOf(false) }
+    var car by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text("Transporter Registration")
+        Row { Checkbox(bicycle, { bicycle = it }); Text("Bicycle") }
+        Row { Checkbox(bike, { bike = it }); Text("Bike") }
+        Row { Checkbox(car, { car = it }); Text("Car") }
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { nav.popBackStack() }) { Text("Submit") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
@@ -20,7 +20,6 @@ import androidx.navigation.NavHostController
 
 @Composable
 fun TransporterSignupScreen(nav: NavHostController) {
-    var name by remember { mutableStateOf("") }
     var bike by remember { mutableStateOf(true) }
     var bicycle by remember { mutableStateOf(false) }
     var car by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/TransporterSignupScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import com.oja.app.data.DeliveryMethod
 
 @Composable
 fun TransporterSignupScreen(nav: NavHostController) {

--- a/app/src/main/java/com/oja/app/ui/screens/VendorSignupScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/VendorSignupScreen.kt
@@ -1,0 +1,26 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+
+@Composable
+fun VendorSignupScreen(nav: NavHostController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text("Vendor Onboarding")
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { nav.popBackStack() }) { Text("Submit") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
@@ -1,0 +1,33 @@
+package com.oja.app.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.oja.app.R
+
+@Composable
+fun WelcomeScreen(onStart: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(16.dp))
+        Text("Welcome to OJA", textAlign = TextAlign.Center)
+        Image(painterResource(id = R.drawable.ic_launcher_foreground), contentDescription = "Agents")
+        Button(onClick = onStart, modifier = Modifier.fillMaxWidth()) { Text("Enter Market") }
+    }
+}

--- a/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/oja/app/ui/screens/WelcomeScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF6F00"
+        android:pathData="M12,12h84v84h-84z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M36,36c12,0 21.6,9.6 21.6,21.6c0,6.4 -2.8,12.2 -7.2,16.2l15.6,15.6l-8.4,8.4l-15.6,-15.6c-4,4.4 -9.8,7.2 -16.2,7.2c-12,0 -21.6,-9.6 -21.6,-21.6c0,-12 9.6,-21.6 21.6,-21.6zM36,48c-5,0 -9.6,4.6 -9.6,9.6c0,5 4.6,9.6 9.6,9.6c5,0 9.6,-4.6 9.6,-9.6c0,-5 -4.6,-9.6 -9.6,-9.6z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="ic_launcher_background">#121212</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">OJA</string>
+    <string name="google_maps_key">YOUR_MAPS_API_KEY_HERE</string>
+    <string name="welcome_title">Welcome to OJA</string>
+    <string name="welcome_sub">Your neighborhood market—street to doorstep</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">OJA</string>
+    <!-- TODO: Replace the value below with your actual Google Maps API key.
+         The map functionality will not work until a valid API key is provided. -->
     <string name="google_maps_key">YOUR_MAPS_API_KEY_HERE</string>
     <string name="welcome_title">Welcome to OJA</string>
     <string name="welcome_sub">Your neighborhood market—street to doorstep</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.4.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+rootProject.name = "OJA"
+include(":app")


### PR DESCRIPTION
## Summary
- add the OjaApp application class and register it in the manifest alongside baseline Android resources
- replace MainActivity with a Compose entry point that renders AppRoot and opt into required experimental APIs
- introduce theming, navigation, root composable, data layer, and screen implementations so every required destination is reachable

## Testing
- gradle help --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf0432119483258c0d3ddc8be89620