### PR TITLE
Adjust manifest backup configuration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <application
         android:name=".OjaApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        tools:replace="android:allowBackup"
         android:label="OJA"
         android:theme="@style/Theme.Material3.DayNight.NoActionBar">
         <activity


### PR DESCRIPTION
## Summary
- add the Android tools namespace to the manifest
- disable backups and allow manifest merge replacement for the application

## Testing
- `./gradlew :app:processDebugMainManifest --console=plain` *(fails: could not download com.github.flutterwave.rave-android:rave_android:2.2.1 from jitpack.io due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d103cf0a008325aed0c40771f9416b