### PR TITLE
Upgrade AGP and Gradle wrapper

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
-    id("com.android.application") version "8.4.2" apply false
+    id("com.android.application") version "8.6.0" apply false
     id("org.jetbrains.kotlin.android") version "2.0.20" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.20" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- bump the Android Gradle Plugin to 8.6.0 and add the Kotlin Compose plugin in the shared buildscript
- apply the Compose Gradle plugin in the app module so Kotlin 2.0 builds continue to configure successfully
- update the Gradle wrapper properties to download Gradle 8.9

## Testing
- `./gradlew :app:checkDebugAarMetadata --console=plain` *(fails: Android SDK is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d103d0a2f48325b2c9b6d4e648ea6d