### PR TITLE
Update Compose compiler for Kotlin 2.0.20

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
     kotlinOptions { jvmTarget = "17" }
 
     buildFeatures { compose = true }
-    composeOptions { kotlinCompilerExtensionVersion = "1.5.14" }
+    composeOptions { kotlinCompilerExtensionVersion = "1.7.1" }
 
     packaging {
         resources.excludes += setOf(


### PR DESCRIPTION
## Summary
- update the Compose compiler extension version used by the app module to 1.7.1 to align with Kotlin 2.0.20

## Testing
- `./gradlew :app:checkDebugAarMetadata --console=plain` *(fails: missing local Android SDK in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10e5984648325b52d87f36a77b5a4