### PR TITLE
Remove explicit Compose compiler override

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,6 @@ android {
     kotlinOptions { jvmTarget = "17" }
 
     buildFeatures { compose = true }
-    composeOptions { kotlinCompilerExtensionVersion = "1.7.1" }
 
     packaging {
         resources.excludes += setOf(


### PR DESCRIPTION
## Summary
- stop overriding the Compose compiler version in the app module so the Kotlin Compose Gradle plugin can supply the matching compiler

## Testing
- ./gradlew :app:checkDebugAarMetadata --console=plain *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d11291e84c832592f430ccf0700424