### PR TITLE
Document launch readiness gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,29 @@ OJA is a Jetpack Compose prototype for a three-sided Nigerian commerce marketpla
 ```text
 app/
 ├── src/main/java/com/oja/app
-│   ├── data/        # In-memory models and repository that simulate marketplace behavior
-│   ├── net/         # WebSocket configuration placeholder pointing to the future backend
-│   ├── navigation/  # Route definitions for Navigation Compose
-│   ├── ui/          # Compose theme, root scaffold, and feature screens
-│   └── MainActivity.kt / OjaApp.kt
-├── src/main/res    # Resources including the Google Maps API key placeholder
+│   ├── core/            # Shared foundation for networking, data stores, logging, etc.
+│   ├── data/            # In-memory models and repository that simulate marketplace behavior
+│   ├── feature/         # Stage-aligned feature packages (auth, payments, logistics, vendor, ...)
+│   ├── net/             # WebSocket configuration placeholder pointing to the future backend
+│   ├── navigation/      # Route definitions for Navigation Compose
+│   └── ui/
+│       ├── components/  # Reusable Compose building blocks and design system glue
+│       ├── screens/     # Feature surfaces, further grouped by buyer/vendor/transporter flows
+│       ├── state/       # UI state holders separate from Composables
+│       └── viewmodel/   # Presentation-layer logic (Hilt wiring will land here later)
+├── src/main/res
+│   ├── color/           # Material color overrides and future dynamic palettes
+│   ├── drawable-night/  # Dark-mode artwork placeholders
+│   ├── font/            # Typeface assets once licensing is cleared
+│   ├── layout/          # XML fallbacks for non-Compose surfaces (if required)
+│   ├── mipmap-anydpi-v26/ # Adaptive launcher icons
+│   ├── raw/             # Seeded JSON and mock API payloads
+│   ├── values-night/    # Dark-mode theming tokens
+│   └── xml/             # Maps/Firebase config files
+├── src/androidTest/     # Instrumented test sources and resources
+├── src/test/            # JVM unit test sources and fixtures
+├── src/debug/           # Debug-only code/resources (e.g., logging overlays)
+├── src/release/         # Release build overrides
 ├── build.gradle.kts
 └── ...
 ```

--- a/app/src/androidTest/java/com/oja/app/.gitkeep
+++ b/app/src/androidTest/java/com/oja/app/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/androidTest/resources/.gitkeep
+++ b/app/src/androidTest/resources/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/debug/java/com/oja/app/.gitkeep
+++ b/app/src/debug/java/com/oja/app/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/debug/res/.gitkeep
+++ b/app/src/debug/res/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/core/database/.gitkeep
+++ b/app/src/main/java/com/oja/app/core/database/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/core/datastore/.gitkeep
+++ b/app/src/main/java/com/oja/app/core/datastore/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/core/location/.gitkeep
+++ b/app/src/main/java/com/oja/app/core/location/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/core/logging/.gitkeep
+++ b/app/src/main/java/com/oja/app/core/logging/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/core/network/.gitkeep
+++ b/app/src/main/java/com/oja/app/core/network/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/core/payments/.gitkeep
+++ b/app/src/main/java/com/oja/app/core/payments/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/core/util/.gitkeep
+++ b/app/src/main/java/com/oja/app/core/util/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/addresses/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/addresses/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/admin/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/admin/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/analytics/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/analytics/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/auth/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/auth/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/cart/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/cart/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/catalog/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/catalog/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/checkout/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/checkout/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/logistics/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/logistics/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/orders/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/orders/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/payments/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/payments/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/privacy/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/privacy/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/support/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/support/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/transporter/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/transporter/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/feature/vendor/.gitkeep
+++ b/app/src/main/java/com/oja/app/feature/vendor/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/components/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/components/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/addresses/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/addresses/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/buyer/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/buyer/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/logistics/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/logistics/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/orders/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/orders/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/payments/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/payments/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/profile/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/profile/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/support/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/support/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/transporter/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/transporter/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/screens/vendor/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/screens/vendor/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/state/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/state/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/java/com/oja/app/ui/viewmodel/.gitkeep
+++ b/app/src/main/java/com/oja/app/ui/viewmodel/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/color/.gitkeep
+++ b/app/src/main/res/color/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/drawable-night/.gitkeep
+++ b/app/src/main/res/drawable-night/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/font/.gitkeep
+++ b/app/src/main/res/font/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/layout/.gitkeep
+++ b/app/src/main/res/layout/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/mipmap-anydpi-v26/.gitkeep
+++ b/app/src/main/res/mipmap-anydpi-v26/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/raw/.gitkeep
+++ b/app/src/main/res/raw/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/values-night/.gitkeep
+++ b/app/src/main/res/values-night/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/main/res/xml/.gitkeep
+++ b/app/src/main/res/xml/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/release/java/com/oja/app/.gitkeep
+++ b/app/src/release/java/com/oja/app/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/release/res/.gitkeep
+++ b/app/src/release/res/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/test/java/com/oja/app/.gitkeep
+++ b/app/src/test/java/com/oja/app/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/app/src/test/resources/.gitkeep
+++ b/app/src/test/resources/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure Git tracks this directory.

--- a/docs/delivery-plan.md
+++ b/docs/delivery-plan.md
@@ -18,6 +18,24 @@ This backlog converts the production blueprint into execution-ready tasks. Each 
 
 ## Production blueprint (no-gap delivery plan)
 
+## Launch-readiness & view-testing milestones
+
+The table below reframes each delivery stage into testable launch checkpoints so teams know exactly when the Android app can be
+opened, exercised, and exposed to real users. Every milestone requires that the listed validation steps be executed and signed
+off before moving to the next stage.
+
+| Stage | Focus | App availability | Required validation before advancing |
+|-------|-------|------------------|---------------------------------------|
+| Stage 0 – Foundation & guardrails | Compliance, processor contracts, infrastructure, IAM | **Internal prototype only.** App may be launched on internal devices using mock data, but no external users or production data. | ✅ Compliance checklist signed, ✅ infrastructure smoke deploys, ✅ security review for IAM/secrets. |
+| Stage A – Payments & address correctness | Replace mocks with real auth/catalog/order/payment/address services and SDK integrations | **Closed staging build.** App can be installed by QA to validate welcome, browse, checkout, address picker, and ₦100 live payments end-to-end. | ✅ Contract/integration tests green, ✅ ₦100 payment run recorded, ✅ Android staging smoke (launch → browse → checkout → receipt). |
+| Stage B – Real-time logistics | Sendbox integration, live tracking, transporter job board | **Staging w/ logistics pilots.** Launchable to pilot couriers and ops to view live order timelines. | ✅ WebSocket load test (<300 ms p95), ✅ Foreground tracking instrumentation test, ✅ Field drive test covering Lagos & Abuja routes. |
+| Stage C – Vendor tooling | Vendor onboarding, catalog management, bulk ingestion | **Extended staging / limited beta.** Vendors can log in and manage catalog via the app. | ✅ Bulk upload stress test (200 images/100 products), ✅ Pen-test storage permissions, ✅ Vendor dashboard UX review on device. |
+| Stage D – Courier operations | Proof-of-delivery, earnings, dispute workflows | **Beta-ready.** Courier network can run COD/POD flows on managed devices. | ✅ Concurrency stress (≥50 claims), ✅ Battery/performance profiling on low-end hardware, ✅ POD capture instrumentation. |
+| Stage E – Trust, support, analytics | Support center, privacy tooling, analytics, notifications | **Public launch candidate.** Buyers, vendors, couriers can install from store once legal sign-off is complete. | ✅ Dispute lifecycle QA, ✅ Data-subject request drill, ✅ Notification/analytics SLI monitoring live. |
+
+> **Launch gate reminder:** External distribution (Play Console listing or production backend traffic) is blocked until the prior
+stage’s validation checklist is complete. Keep the staging build separate from production until Stage E verification concludes.
+
 ### Stage 0 – Foundation & guardrails
 - **Organisational readiness:** Appoint DPO, document NDPA processing records, and finalise incident-response playbooks before ingesting production data.
 - **Processor agreements:** Countersign Paystack, Flutterwave, Sendbox, and Kwik DPAs; enable Google Cloud billing with Maps budget alerts.


### PR DESCRIPTION
## Summary
- add a launch-readiness and view-testing milestone table to the delivery plan so teams know when the app can be exercised
- clarify that each stage requires validation before exposing the build to broader audiences

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68d1193a022c83259cc360bbaee842c0